### PR TITLE
fix: clear legacy auth cookies before sign-in

### DIFF
--- a/components/login/LoginForm.tsx
+++ b/components/login/LoginForm.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -13,7 +12,7 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
-import { signIn, getSession, debugFetchSession, AUTH_BASE_URL } from '@/lib/auth-client';
+import { signIn, getSession, debugFetchSession, AUTH_BASE_URL, clearLegacyCookies } from '@/lib/auth-client';
 import { config } from '@/lib/config';
 
 interface SessionResponse {
@@ -42,7 +41,6 @@ export default function LoginForm({
   description = "Sign in to your tostendout account",
   submitText = "Sign In"
 }: LoginFormProps) {
-  const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -59,6 +57,7 @@ export default function LoginForm({
     setError(null);
     
     try {
+      await clearLegacyCookies();
       const result = await signIn.email({
         email: data.email,
         password: data.password,

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React, { createContext, useContext } from 'react';
-import { useSession, debugFetchSession, AUTH_BASE_URL } from '@/lib/auth-client';
-import { config } from '@/lib/config';
+import { useSession, debugFetchSession, AUTH_BASE_URL, clearLegacyCookies } from '@/lib/auth-client';
 
 interface User {
   id: string;
@@ -77,11 +76,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // Auto-attempt clearing legacy cookies once per page load to fix stuck sessions
     if (!attemptedCookieReset) {
       (globalThis as any).__avnAttemptedCookieReset = true;
-      const clearUrl = `${config.api.baseUrl.replace(/\/$/, '')}/auth/clear-legacy-cookies`;
-      console.log('🟡 AuthProvider Debug: attempting legacy cookie clear at', clearUrl);
-      fetch(clearUrl, { method: 'POST', credentials: 'include' })
-        .then(res => console.log('🟡 clear-legacy-cookies status:', res.status))
-        .catch(e => console.warn('🟡 clear-legacy-cookies failed:', e));
+      console.log('🟡 AuthProvider Debug: attempting legacy cookie clear');
+      clearLegacyCookies();
     }
   }
   

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -82,6 +82,18 @@ export async function debugFetchSession() {
   }
 }
 
+// Helper to clear legacy cookies that might interfere with new sessions
+export async function clearLegacyCookies() {
+  const url = `${AUTH_BASE}/clear-legacy-cookies`;
+  try {
+    console.log('🔵 clearLegacyCookies: Request', { url });
+    const res = await fetch(url, { method: 'POST', credentials: 'include' });
+    console.log('🔵 clearLegacyCookies: Response status', res.status);
+  } catch (e) {
+    console.warn('🟡 clearLegacyCookies failed', e);
+  }
+}
+
 // Interface for extended signup payload with additional fields
 interface ExtendedSignupPayload {
   email: string;


### PR DESCRIPTION
## Summary
- add utility to clear legacy Better Auth cookies
- invoke legacy cookie clear in AuthProvider and before sign-in

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b8a0a6587c83258d5db9de5b3ad4de